### PR TITLE
refactor:tailwindcss-railsをアンインストール #29

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,6 @@ group :test do
   gem "selenium-webdriver"
 end
 
-gem "tailwindcss-rails"
-gem "tailwindcss-ruby"
 gem "inline_svg"
 gem "rails-i18n"
 gem "front_matter_parser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,16 +300,6 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
-    tailwindcss-rails (4.3.0)
-      railties (>= 7.0.0)
-      tailwindcss-ruby (~> 4.0)
-    tailwindcss-ruby (4.1.12)
-    tailwindcss-ruby (4.1.12-aarch64-linux-gnu)
-    tailwindcss-ruby (4.1.12-aarch64-linux-musl)
-    tailwindcss-ruby (4.1.12-arm64-darwin)
-    tailwindcss-ruby (4.1.12-x86_64-darwin)
-    tailwindcss-ruby (4.1.12-x86_64-linux-gnu)
-    tailwindcss-ruby (4.1.12-x86_64-linux-musl)
     temple (0.10.4)
     thor (1.4.0)
     tilt (2.6.1)
@@ -370,8 +360,6 @@ DEPENDENCIES
   slim_lint
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails
-  tailwindcss-ruby
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
 js: yarn build --watch
 css: yarn build:css --watch
-css: bin/rails tailwindcss:watch

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
+@plugin "daisyui" {
+  themes: cupcake --default;
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,5 +1,0 @@
-@import "tailwindcss";
-@plugin "@tailwindcss/typography";
-@plugin "daisyui" {
-  themes: cupcake --default;
-}


### PR DESCRIPTION
## 概要
tailwindcss-railsが不要のためアンインストールしました。